### PR TITLE
Add x-internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ fizz.InputModel(model interface{})
 
 // Add a Code Sample to the operation.
 fizz.XCodeSample(codeSample *XCodeSample)
+
+// Mark the operation as internal or external.
+fizz.XInternal(isInternal bool)
 ```
 
 **NOTES:**

--- a/fizz.go
+++ b/fizz.go
@@ -360,6 +360,13 @@ func XCodeSample(cs *openapi.XCodeSample) func(*openapi.OperationInfo) {
 	}
 }
 
+// XInternal marks the operation as internal or external.
+func XInternal(isInternal bool) func(*openapi.OperationInfo) {
+	return func(o *openapi.OperationInfo) {
+		o.XInternal = isInternal
+	}
+}
+
 // OperationFromContext returns the OpenAPI operation from
 // the givent Gin context or an error if none is found.
 func OperationFromContext(c *gin.Context) (*openapi.Operation, error) {

--- a/fizz_test.go
+++ b/fizz_test.go
@@ -271,6 +271,7 @@ func TestSpecHandler(t *testing.T) {
 				Label:  "v4.4",
 				Source: "curl http://0.0.0.0:8080",
 			}),
+			XInternal(true),
 		},
 		tonic.Handler(func(c *gin.Context) error {
 			return nil

--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -251,6 +251,7 @@ func (g *Generator) AddOperation(path, method, tag string, in, out reflect.Type,
 		op.Deprecated = info.Deprecated
 		op.Responses = make(Responses)
 		op.XCodeSamples = info.XCodeSamples
+		op.XInternal = info.XInternal
 	}
 	if tag != "" {
 		op.Tags = append(op.Tags, tag)

--- a/openapi/operation.go
+++ b/openapi/operation.go
@@ -13,6 +13,7 @@ type OperationInfo struct {
 	InputModel        interface{}
 	Responses         []*OperationResponse
 	XCodeSamples      []*XCodeSample
+	XInternal         bool
 }
 
 // ResponseHeader represents a single header that

--- a/openapi/spec.go
+++ b/openapi/spec.go
@@ -194,6 +194,7 @@ type Operation struct {
 	Deprecated   bool              `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 	Servers      []*Server         `json:"servers,omitempty" yaml:"servers,omitempty"`
 	XCodeSamples []*XCodeSample    `json:"x-codeSamples,omitempty" yaml:"x-codeSamples,omitempty"`
+	XInternal    bool              `json:"x-internal,omitempty" yaml:"x-internal,omitempty"`
 }
 
 // Responses represents a container for the expected responses

--- a/testdata/spec.json
+++ b/testdata/spec.json
@@ -94,7 +94,8 @@
                         "label":"v4.4",
                         "source":"curl http://0.0.0.0:8080"
                     }
-                ]
+                ],
+                "x-internal": true
             }
         },
         "/test/{a}/{b}": {

--- a/testdata/spec.yaml
+++ b/testdata/spec.yaml
@@ -63,6 +63,7 @@ paths:
         - lang: Shell
           label: v4.4
           source: curl http://0.0.0.0:8080
+      x-internal: true
   /test/{a}/{b}:
     get:
       operationId: GetTest2


### PR DESCRIPTION
This PR adds the support for marking the endpoints as `x-internal`, which is a mechanism for hiding endpoints in the rendered docs.

# Background
Some docs rendering tools (e.g. [ReDoc](https://redoc.ly/docs/cli/guides/hide-apis/#1-marking-paths-and-operations-with-x-internal-true) and [Elements](https://github.com/stoplightio/elements/blob/main/docs/getting-started/usage/web-component.md#configuration)) support the functionality of the endpoints to be hidden from the docs, if they are marked as `x-internal`. The changes here add the support for `x-internal`.